### PR TITLE
WIP - signed/gasless contract creation

### DIFF
--- a/src/factory/ZoraCreator1155FactoryImpl.sol
+++ b/src/factory/ZoraCreator1155FactoryImpl.sol
@@ -15,10 +15,10 @@ import {Zora1155} from "../proxies/Zora1155.sol";
 
 import {ContractVersionBase} from "../version/ContractVersionBase.sol";
 
-import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
-import {ECDSAUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
+import {EIP712Upgradeable} from "@zoralabs/openzeppelin-contracts-upgradeable/contracts/utils/cryptography/EIP712Upgradeable.sol";
+import {ECDSAUpgradeable} from "@zoralabs/openzeppelin-contracts-upgradeable/contracts/utils/cryptography/ECDSAUpgradeable.sol";
 
-import {Create2Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/Create2Upgradeable.sol";
+import {Create2Upgradeable} from "@zoralabs/openzeppelin-contracts-upgradeable/contracts/utils/Create2Upgradeable.sol";
 
 error InvalidDelegateSignature();
 error InvalidNonce();
@@ -39,8 +39,6 @@ contract ZoraCreator1155FactoryImpl is
     IMinter1155 public immutable fixedPriceMinter;
     IMinter1155 public immutable redeemMinterFactory;
 
-    string constant CONTRACT_NAME = "ZORA 1155 Contract Factory";
-
     constructor(IZoraCreator1155 _implementation, IMinter1155 _merkleMinter, IMinter1155 _fixedPriceMinter, IMinter1155 _redeemMinterFactory) initializer {
         implementation = _implementation;
         if (address(implementation) == address(0)) {
@@ -57,8 +55,8 @@ contract ZoraCreator1155FactoryImpl is
     }
 
     /// @notice The name of the sale strategy
-    function contractName() external pure returns (string memory) {
-        return CONTRACT_NAME;
+    function contractName() public pure returns (string memory) {
+        return "ZORA 1155 Contract Factory";
     }
 
     /// @notice The default minters for new 1155 contracts
@@ -71,7 +69,7 @@ contract ZoraCreator1155FactoryImpl is
 
     function initialize(address _initialOwner) public initializer {
         __Ownable_init(_initialOwner);
-        __EIP712_init(CONTRACT_NAME, contractVersion());
+        __EIP712_init(contractName(), contractVersion());
         __UUPSUpgradeable_init();
 
         emit FactorySetup();

--- a/src/factory/ZoraCreator1155FactoryImpl.sol
+++ b/src/factory/ZoraCreator1155FactoryImpl.sol
@@ -123,7 +123,20 @@ contract ZoraCreator1155FactoryImpl is
         ICreatorRoyaltiesControl.RoyaltyConfiguration calldata defaultRoyaltyConfiguration,
         bytes[] calldata setupActions,
         bytes calldata signature
-    ) external returns (address) {
+    ) external returns (address newContract) {
+        newContract = _createDelegatedContract(creator, newContractURI, name, defaultRoyaltyConfiguration, setupActions, signature);
+
+        _initializeContract(newContract, creator, newContractURI, name, defaultRoyaltyConfiguration, creator, setupActions);
+    }
+
+    function _createDelegatedContract(
+        address payable creator,
+        string calldata newContractURI,
+        string calldata name,
+        ICreatorRoyaltiesControl.RoyaltyConfiguration calldata defaultRoyaltyConfiguration,
+        bytes[] calldata setupActions,
+        bytes calldata signature
+    ) private returns (address newContract) {
         bytes32 digest = delegateCreateContractHashTypeData(creator, newContractURI, name, defaultRoyaltyConfiguration, setupActions);
 
         address signatory = ECDSAUpgradeable.recover(digest, signature);
@@ -133,11 +146,7 @@ contract ZoraCreator1155FactoryImpl is
         }
 
         // create contract using deterministic address based on the salt (which is the arguments)
-        address newContract = address(new Zora1155{salt: digest}(address(implementation)));
-
-        _initializeContract(newContract, creator, newContractURI, name, defaultRoyaltyConfiguration, creator, setupActions);
-
-        return newContract;
+        newContract = address(new Zora1155{salt: digest}(address(implementation)));
     }
 
     /// Used to preview what a delegated created contract's address will be.  That address is deterministic

--- a/src/version/ContractVersionBase.sol
+++ b/src/version/ContractVersionBase.sol
@@ -7,7 +7,7 @@ import {IVersionedContract} from "../interfaces/IVersionedContract.sol";
 /// @notice Base contract for versioning contracts
 contract ContractVersionBase is IVersionedContract {
     /// @notice The version of the contract
-    function contractVersion() external pure override returns (string memory) {
+    function contractVersion() public pure override returns (string memory) {
         return "1.3.0";
     }
 }

--- a/test/factory/ZoraCreator1155Factory.t.sol
+++ b/test/factory/ZoraCreator1155Factory.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 import "forge-std/Test.sol";
-import {ZoraCreator1155FactoryImpl} from "../../src/factory/ZoraCreator1155FactoryImpl.sol";
+import {ZoraCreator1155FactoryImpl, InvalidDelegateSignature, InvalidNonce} from "../../src/factory/ZoraCreator1155FactoryImpl.sol";
 import {ZoraCreator1155Impl} from "../../src/nft/ZoraCreator1155Impl.sol";
 import {Zora1155Factory} from "../../src/proxies/Zora1155Factory.sol";
 import {IZoraCreator1155Factory} from "../../src/interfaces/IZoraCreator1155Factory.sol";
@@ -10,6 +10,10 @@ import {IZoraCreator1155} from "../../src/interfaces/IZoraCreator1155.sol";
 import {IMinter1155} from "../../src/interfaces/IMinter1155.sol";
 import {ICreatorRoyaltiesControl} from "../../src/interfaces/ICreatorRoyaltiesControl.sol";
 import {MockContractMetadata} from "../mock/MockContractMetadata.sol";
+
+import {ECDSAUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
+
+import {Create2Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/Create2Upgradeable.sol";
 
 contract ZoraCreator1155FactoryTest is Test {
     ZoraCreator1155FactoryImpl internal factory;
@@ -119,5 +123,165 @@ contract ZoraCreator1155FactoryTest is Test {
         vm.prank(initialOwner);
         vm.expectRevert(abi.encodeWithSignature("UpgradeToMismatchedContractName(string,string)", "ZORA 1155 Contract Factory", "name"));
         proxy.upgradeTo(address(mockContractMetadata));
+    }
+
+    // we dont need a nonce - we can deterministically determine the created contract address - and ensure its not created twice
+    // we can recover the address of the creator using ec recover
+    // can we use create2? - since we are using an upgradeable contract, the new contract is created
+    // with just the implementation as an argument. We can't use create2 to deterministically create the contract
+    // what about an end date?
+
+    function test_delegateCreateContract_succeedsWithValidSignature() external {
+        // generate a signature for desired contract
+
+        string memory contractUri = "ipfs://asdfadsf";
+        string memory name = "asdfasdf";
+        ICreatorRoyaltiesControl.RoyaltyConfiguration memory royaltyConfig = _createExampleRoyaltyConfig();
+
+        bytes[] memory initSetup = _createExampleInitSetup();
+
+        uint256 creatorPrivateKey = 0xA11CE;
+
+        address payable creator = payable(vm.addr(creatorPrivateKey));
+
+        // generate hash of arguments for contract creation
+        bytes32 digest = factory.delegateCreateContractHashTypeData(creator, contractUri, name, royaltyConfig, initSetup);
+
+        // generate signature for hash using creators private key
+        bytes memory signature = _sign(creatorPrivateKey, digest);
+
+        address executor = vm.addr(100);
+        vm.prank(executor);
+
+        // someone else creates the contract - the signature must have been generated using these same arguments
+        address createdContract = factory.delegateCreateContract(creator, contractUri, name, royaltyConfig, initSetup, signature);
+
+        ZoraCreator1155Impl target = ZoraCreator1155Impl(createdContract);
+
+        // validate that the owner/admin of the created contract is the original signer.
+        assertEq(target.owner(), creator);
+    }
+
+    function test_delegateCreateContract_failsWithBadArguments(
+        bool badCreator,
+        bool badContractUri,
+        bool badName,
+        bool badRoyaltyConfig,
+        bool badInitSetup,
+        bool badSignature
+    ) external {
+        string memory contractUri = "ipfs://asdfadsf";
+        string memory name = "asdfasdf";
+        ICreatorRoyaltiesControl.RoyaltyConfiguration memory royaltyConfig = _createExampleRoyaltyConfig();
+
+        bytes[] memory initSetup = _createExampleInitSetup();
+
+        uint256 creatorPrivateKey = 0xA11CE;
+
+        address payable creator = payable(vm.addr(creatorPrivateKey));
+
+        bytes32 digest = factory.delegateCreateContractHashTypeData(creator, contractUri, name, royaltyConfig, initSetup);
+
+        bytes memory signature = _sign(creatorPrivateKey, digest);
+
+        if (badSignature) {
+            // change the signature to be invalid
+            signature[0] = 0x00;
+        }
+
+        // if any of the fuzzy parameters indicate a bad arg, then we change the arg to be a mismatch from the sign, and we should
+        // get an error on the creation of the contract
+        address newCreator = badCreator ? vm.addr(1000) : creator;
+        string memory newContractUriString = badContractUri ? "asdfasdf" : contractUri;
+        string memory newNameString = badName ? "adf" : name;
+        if (badRoyaltyConfig) {
+            royaltyConfig.royaltyBPS = 10;
+        }
+
+        if (badInitSetup) {
+            initSetup[0] = abi.encodeWithSelector(IZoraCreator1155.setupNewToken.selector, "ipfs://", 1);
+        }
+
+        // if any are bad, then expect revert
+        if (badSignature) {
+            // todo: figure out specific errors for bad signature
+            vm.expectRevert();
+        } else if (badCreator || badContractUri || badName || badRoyaltyConfig || badInitSetup) {
+            vm.expectRevert(InvalidDelegateSignature.selector);
+        }
+
+        // call delegate create with new args
+        factory.delegateCreateContract(payable(newCreator), newContractUriString, newNameString, royaltyConfig, initSetup, signature);
+    }
+
+    function test_delegateCreateContract_signatureCannotBeExecutedTwice() external {
+        string memory contractUri = "ipfs://asdfadsf";
+        string memory name = "asdfasdf";
+        ICreatorRoyaltiesControl.RoyaltyConfiguration memory royaltyConfig = _createExampleRoyaltyConfig();
+
+        bytes[] memory initSetup = _createExampleInitSetup();
+
+        uint256 creatorPrivateKey = 0xA11CE;
+
+        address payable creator = payable(vm.addr(creatorPrivateKey));
+
+        bytes32 digest = factory.delegateCreateContractHashTypeData(creator, contractUri, name, royaltyConfig, initSetup);
+
+        bytes memory signature = _sign(creatorPrivateKey, digest);
+
+        factory.delegateCreateContract(creator, contractUri, name, royaltyConfig, initSetup, signature);
+
+        vm.expectRevert();
+
+        factory.delegateCreateContract(creator, contractUri, name, royaltyConfig, initSetup, signature);
+    }
+
+    function test_canDetermineContractAddress() external {
+        string memory contractUri = "ipfs://asdfadsf";
+        string memory name = "asdfasdf";
+        ICreatorRoyaltiesControl.RoyaltyConfiguration memory royaltyConfig = _createExampleRoyaltyConfig();
+
+        bytes[] memory initSetup = _createExampleInitSetup();
+
+        uint256 creatorPrivateKey = 0xA11CE;
+
+        address payable creator = payable(vm.addr(creatorPrivateKey));
+
+        bytes32 digest = factory.delegateCreateContractHashTypeData(creator, contractUri, name, royaltyConfig, initSetup);
+
+        bytes memory signature = _sign(creatorPrivateKey, digest);
+
+        address createdAddress = factory.delegateCreateContract(creator, contractUri, name, royaltyConfig, initSetup, signature);
+
+        address expectedAddress = factory.computeDelegateCreatedContractAddress(digest);
+
+        console.log(expectedAddress);
+
+        assertEq(createdAddress, expectedAddress);
+    }
+
+    function _sign(uint256 privateKey, bytes32 digest) private pure returns (bytes memory) {
+        // sign the message
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+
+        // combine into a single bytes array
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _createExampleRoyaltyConfig() private pure returns (ICreatorRoyaltiesControl.RoyaltyConfiguration memory) {
+        ICreatorRoyaltiesControl.RoyaltyConfiguration memory royaltyConfig = ICreatorRoyaltiesControl.RoyaltyConfiguration({
+            royaltyBPS: 100,
+            royaltyRecipient: address(0x123),
+            royaltyMintSchedule: 0
+        });
+
+        return royaltyConfig;
+    }
+
+    function _createExampleInitSetup() private pure returns (bytes[] memory) {
+        bytes[] memory initSetup = new bytes[](1);
+        initSetup[0] = abi.encodeWithSelector(IZoraCreator1155.setupNewToken.selector, "ipfs://asdfadsf", 100);
+
+        return initSetup;
     }
 }


### PR DESCRIPTION
This PR explores how creators can create erc1155 contracts without needing to spend gas, by signing a message and having another account execute it and spend the gas on their behalf.

Reference materials:
* [EIP-712](https://eips.ethereum.org/EIPS/eip-712)
* [Gasless thoughts w/ potential sketch solution](https://docs.google.com/document/d/1gh7DxQJ5ssOH9JglR5q1YBYpnYniay5GRqzrzrofkhY/edit)
* [Create2](https://docs.openzeppelin.com/cli/2.8/deploying-with-create2)

To see the general flow, check out the new tests.

Current features:
* A creator can sign a message off-chain to create a contract with the same arguments as if they were creating a contract normally.
* Anyone can execute that signed message to create a contract on that creators behalf.
* The contract address to be created can be deterministically determined and known ahead of time.
* ~~The signed message cannot be executed twice; this is enforced via a `nonce`.~~

Some caveats:  The signer of the message must match the admin address.  The reason is that it anyone could sign a message to be executed by someone else, and assign any address to the admin address.   Not sure about this restriction and it may make sense to remove it.

The signature and function arguments must be stored off-chain somewhere.

This PR does not take into consideration incentive models.

Other improvement: in the factory, change arguments to be calldata instead of memory to save on gas.