### PR TITLE
Include contract source and typescript source in export

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "prettier": "prettier --write 'src/**/*.sol' 'test/**/*.sol' 'package/**/*.ts' 'wagmi.config.ts'",
     "coverage": "forge coverage --report lcov",
     "write-gas-report": "forge test --gas-report > gasreport.ansi",
-    "prepack": "node script/copy-deployed-contracts.mjs && yarn wagmi && yarn bundle-configs && yarn build-ts",
-    "build-ts": "tsup package/index.ts --format cjs --dts --sourcemap",
+    "prepack": "node script/copy-deployed-contracts.mjs && yarn wagmi && yarn bundle-configs && yarn build",
+    "build": "tsup",
     "bundle-configs": "node script/bundle-chainConfigs.mjs && yarn prettier",
     "wagmi": "wagmi generate",
     "storage-inspect:check": "./script/storage-check.sh check ZoraCreator1155Impl ZoraCreator1155FactoryImpl",
@@ -25,11 +25,9 @@
     "dist/",
     "src/",
     "addresses/",
-    "chainConfigs/"
+    "chainConfigs/",
+    "package/"
   ],
-  "exports": {
-    "./contracts": "./src"
-  },
   "dependencies": {
     "@openzeppelin/contracts": "4.8.3",
     "@zoralabs/openzeppelin-contracts-upgradeable": "^4.8.4",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "addresses/",
     "chainConfigs/"
   ],
+  "exports": {
+    "./contracts": "./src"
+  },
   "dependencies": {
     "@openzeppelin/contracts": "4.8.3",
     "@zoralabs/openzeppelin-contracts-upgradeable": "^4.8.4",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "prettier": "prettier --write 'src/**/*.sol' 'test/**/*.sol' 'package/**/*.ts' 'wagmi.config.ts'",
     "coverage": "forge coverage --report lcov",
     "write-gas-report": "forge test --gas-report > gasreport.ansi",
-    "prepack": "node script/copy-deployed-contracts.mjs && yarn wagmi && yarn bundle-configs && yarn build-ts && yarn copy-addresses-and-configs",
+    "prepack": "node script/copy-deployed-contracts.mjs && yarn wagmi && yarn bundle-configs && yarn build-ts && yarn copy-files-to-bundle",
     "build-ts": "tsup package/index.ts --format cjs --dts --sourcemap",
     "bundle-configs": "node script/bundle-chainConfigs.mjs && yarn prettier",
-    "copy-addresses-and-configs": "cp -r addresses/ dist/addresses && cp -r chainConfigs/ dist/chainConfigs",
+    "copy-files-to-bundle": "cp -r addresses/ dist/addresses && cp -r chainConfigs/ dist/chainConfigs && rm -rf dist/contracts && cp -r src dist/contracts",
     "wagmi": "wagmi generate",
     "storage-inspect:check": "./script/storage-check.sh check ZoraCreator1155Impl ZoraCreator1155FactoryImpl",
     "storage-inspect:generate": "./script/storage-check.sh generate ZoraCreator1155Impl ZoraCreator1155FactoryImpl"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoralabs/zora-1155-contracts",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "repository": "git@github.com:ourzora/creator-contracts.git",
   "author": "Iain <iain@zora.co>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -14,16 +14,18 @@
     "prettier": "prettier --write 'src/**/*.sol' 'test/**/*.sol' 'package/**/*.ts' 'wagmi.config.ts'",
     "coverage": "forge coverage --report lcov",
     "write-gas-report": "forge test --gas-report > gasreport.ansi",
-    "prepack": "node script/copy-deployed-contracts.mjs && yarn wagmi && yarn bundle-configs && yarn build-ts && yarn copy-files-to-bundle",
+    "prepack": "node script/copy-deployed-contracts.mjs && yarn wagmi && yarn bundle-configs && yarn build-ts",
     "build-ts": "tsup package/index.ts --format cjs --dts --sourcemap",
     "bundle-configs": "node script/bundle-chainConfigs.mjs && yarn prettier",
-    "copy-files-to-bundle": "cp -r addresses/ dist/addresses && cp -r chainConfigs/ dist/chainConfigs && rm -rf dist/contracts && cp -r src dist/contracts",
     "wagmi": "wagmi generate",
     "storage-inspect:check": "./script/storage-check.sh check ZoraCreator1155Impl ZoraCreator1155FactoryImpl",
     "storage-inspect:generate": "./script/storage-check.sh generate ZoraCreator1155Impl ZoraCreator1155FactoryImpl"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "src/",
+    "addresses/",
+    "chainConfigs/"
   ],
   "dependencies": {
     "@openzeppelin/contracts": "4.8.3",

--- a/src/version/ContractVersionBase.sol
+++ b/src/version/ContractVersionBase.sol
@@ -8,6 +8,6 @@ import {IVersionedContract} from "../interfaces/IVersionedContract.sol";
 contract ContractVersionBase is IVersionedContract {
     /// @notice The version of the contract
     function contractVersion() external pure override returns (string memory) {
-        return "1.3.1";
+        return "1.3.2";
     }
 }

--- a/test/factory/ZoraCreator1155Factory.t.sol
+++ b/test/factory/ZoraCreator1155Factory.t.sol
@@ -20,7 +20,7 @@ contract ZoraCreator1155FactoryTest is Test {
     }
 
     function test_contractVersion() external {
-        assertEq(factory.contractVersion(), "1.3.1");
+        assertEq(factory.contractVersion(), "1.3.2");
     }
 
     function test_contractName() external {

--- a/test/nft/ZoraCreator1155.t.sol
+++ b/test/nft/ZoraCreator1155.t.sol
@@ -126,7 +126,7 @@ contract ZoraCreator1155Test is Test {
     function test_contractVersion() external {
         init();
 
-        assertEq(target.contractVersion(), "1.3.1");
+        assertEq(target.contractVersion(), "1.3.2");
     }
 
     function test_assumeLastTokenIdMatches() external {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "strictNullChecks": true,
     "target": "es2021",
     "types": ["node"],
-  "outDir": "dist"
+    "outDir": "dist"
   },
   "exclude": ["node_modules/**", "dist/**"],
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "lib": ["es2021"],
     "module": "esnext",
     "moduleResolution": "node",
-    "noEmit": true,
     "noImplicitAny": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
@@ -18,11 +17,12 @@
     "strict": true,
     "strictNullChecks": true,
     "target": "es2021",
-    "types": ["node"]
+    "types": ["node"],
+  "outDir": "dist"
   },
   "exclude": ["node_modules/**", "dist/**"],
   "include": [
     "package/**/*.ts",
     "js-scripts/**/*.mjs"
-  ]
+  ],
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['package/index.ts'],
+  sourcemap: true,
+  clean: true,
+  dts: false,
+  format: ['cjs'],
+  onSuccess: 'tsc --emitDeclarationOnly --declaration --declarationMap'
+})


### PR DESCRIPTION
Improvements to the published package; the new published folder structure looks like:

<img width="474" alt="Screenshot 2023-06-23 at 10 42 22 AM" src="https://github.com/ourzora/zora-1155-contracts/assets/891755/5b679120-9f56-4794-b17b-5adbb7add65e">

* contract source code, addresses json, and config json are now bundled with the package, in the folder `/src` and `/addresses` and `/chainConfigs` correspondingly.
* You can now go to directly the typescript source file when going to definition instead of the type declaration file..  This is achieved by running the post build step `tsc --emitDeclarationOnly --declaration --declarationMap`, documented [here](https://www.typescriptlang.org/tsconfig#declarationMap)
* tsup config moved to `tsup.config.ts`