### PR TITLE
Premint: add creator to creator attribution event

### DIFF
--- a/src/interfaces/IZoraCreator1155.sol
+++ b/src/interfaces/IZoraCreator1155.sol
@@ -60,6 +60,7 @@ interface IZoraCreator1155 is IZoraCreator1155TypesV1, IVersionedContract, IOwna
     event ContractRendererUpdated(IRenderer1155 renderer);
     event ContractMetadataUpdated(address indexed updater, string uri, string name);
     event Purchased(address indexed sender, address indexed minter, uint256 indexed tokenId, uint256 quantity, uint256 value);
+    event CreatorAttribution(bytes32 structHash, string domainName, string version, address creator, bytes signature);
 
     error TokenIdMismatch(uint256 expected, uint256 actual);
     error UserMissingRoleForToken(address user, uint256 tokenId, uint256 role);

--- a/src/nft/ZoraCreator1155Impl.sol
+++ b/src/nft/ZoraCreator1155Impl.sol
@@ -727,10 +727,6 @@ contract ZoraCreator1155Impl is
     /* start eip712 functionality */
     mapping(uint32 => uint256) public delegatedTokenId;
 
-    event CreatorAttribution(bytes32 structHash, bytes32 domainName, bytes32 version, address creator, bytes signature);
-
-    error PremintAlreadyExecuted();
-
     function delegateSetupNewToken(PremintConfig calldata premintConfig, bytes calldata signature) public nonReentrant returns (uint256 newTokenId) {
         // if a token has already been created for a premint config with this uid:
         if (delegatedTokenId[premintConfig.uid] != 0) {
@@ -744,7 +740,7 @@ contract ZoraCreator1155Impl is
         address creator = ZoraCreator1155Attribution.recoverSignerHashed(hashedPremintConfig, signature, address(this), block.chainid);
 
         // this is what attributes this token to have been created by the original creator
-        emit CreatorAttribution(hashedPremintConfig, ZoraCreator1155Attribution.HASHED_NAME, ZoraCreator1155Attribution.HASHED_VERSION, creator, signature);
+        emit CreatorAttribution(hashedPremintConfig, ZoraCreator1155Attribution.NAME, ZoraCreator1155Attribution.VERSION, creator, signature);
 
         // require that the signer can create new tokens (is a valid creator)
         _requireAdminOrRole(creator, CONTRACT_BASE_ID, PERMISSION_BIT_MINTER);

--- a/src/nft/ZoraCreator1155Impl.sol
+++ b/src/nft/ZoraCreator1155Impl.sol
@@ -727,7 +727,7 @@ contract ZoraCreator1155Impl is
     /* start eip712 functionality */
     mapping(uint32 => uint256) public delegatedTokenId;
 
-    event CreatorAttribution(bytes32 structHash, bytes32 domainName, bytes32 version, bytes signature);
+    event CreatorAttribution(bytes32 structHash, bytes32 domainName, bytes32 version, address creator, bytes signature);
 
     error PremintAlreadyExecuted();
 
@@ -740,14 +740,14 @@ contract ZoraCreator1155Impl is
 
         bytes32 hashedPremintConfig = ZoraCreator1155Attribution.validateAndHashPremint(premintConfig);
 
-        // this is what attributes this token to have been created by the original creator
-        emit CreatorAttribution(hashedPremintConfig, ZoraCreator1155Attribution.HASHED_NAME, ZoraCreator1155Attribution.HASHED_VERSION, signature);
-
         // recover the signer from the data
-        address recoveredSigner = ZoraCreator1155Attribution.recoverSignerHashed(hashedPremintConfig, signature, address(this), block.chainid);
+        address creator = ZoraCreator1155Attribution.recoverSignerHashed(hashedPremintConfig, signature, address(this), block.chainid);
+
+        // this is what attributes this token to have been created by the original creator
+        emit CreatorAttribution(hashedPremintConfig, ZoraCreator1155Attribution.HASHED_NAME, ZoraCreator1155Attribution.HASHED_VERSION, creator, signature);
 
         // require that the signer can create new tokens (is a valid creator)
-        _requireAdminOrRole(recoveredSigner, CONTRACT_BASE_ID, PERMISSION_BIT_MINTER);
+        _requireAdminOrRole(creator, CONTRACT_BASE_ID, PERMISSION_BIT_MINTER);
 
         // create the new token; msg sender will have PERMISSION_BIT_ADMIN on the new token
         newTokenId = _setupNewTokenAndPermission(premintConfig.tokenConfig.tokenURI, premintConfig.tokenConfig.maxSupply, msg.sender, PERMISSION_BIT_ADMIN);
@@ -755,7 +755,7 @@ contract ZoraCreator1155Impl is
         delegatedTokenId[premintConfig.uid] = newTokenId;
 
         // invoke setup actions for new token, to save contract size, first get them from an external lib
-        bytes[] memory tokenSetupActions = PremintTokenSetup.makeSetupNewTokenCalls(newTokenId, recoveredSigner, premintConfig.tokenConfig);
+        bytes[] memory tokenSetupActions = PremintTokenSetup.makeSetupNewTokenCalls(newTokenId, creator, premintConfig.tokenConfig);
 
         // then invoke them, calling account should be original msg.sender, which has admin on the new token
         _multicallInternal(tokenSetupActions);
@@ -764,6 +764,6 @@ contract ZoraCreator1155Impl is
         _removePermission(newTokenId, msg.sender, PERMISSION_BIT_ADMIN);
 
         // grant the token creator as admin of the newly created token
-        _addPermission(newTokenId, recoveredSigner, PERMISSION_BIT_ADMIN);
+        _addPermission(newTokenId, creator, PERMISSION_BIT_ADMIN);
     }
 }

--- a/src/premint/ZoraCreator1155Attribution.sol
+++ b/src/premint/ZoraCreator1155Attribution.sol
@@ -58,9 +58,11 @@ struct PremintConfig {
 /// @author @oveddan
 library ZoraCreator1155Attribution {
     /* start eip712 functionality */
-    bytes32 public constant HASHED_NAME = keccak256(bytes("Preminter"));
-    bytes32 public constant HASHED_VERSION = keccak256(bytes("1"));
-    bytes32 public constant TYPE_HASH = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    string internal constant NAME = "Preminter";
+    string internal constant VERSION = "1";
+    bytes32 internal constant HASHED_NAME = keccak256(bytes(NAME));
+    bytes32 internal constant HASHED_VERSION = keccak256(bytes(VERSION));
+    bytes32 internal constant TYPE_HASH = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
 
     /**
      * @dev Returns the domain separator for the specified chain.


### PR DESCRIPTION
* Add creator address to creator attribution event.
* Convert creator attribution fields for `name` and `version` from `bytes32` to `string` (to follow the standard)
* Added test that verifies creator attribution event emitted