### PR TITLE
Premint: fix fork tests

### DIFF
--- a/.storage-layout
+++ b/.storage-layout
@@ -33,6 +33,7 @@
 | permissions              | mapping(uint256 => mapping(address => uint256))                          | 510  | 0      | 32    | src/nft/ZoraCreator1155Impl.sol:ZoraCreator1155Impl |
 | __gap                    | uint256[50]                                                              | 511  | 0      | 1600  | src/nft/ZoraCreator1155Impl.sol:ZoraCreator1155Impl |
 | createReferrals          | mapping(uint256 => address)                                              | 561  | 0      | 32    | src/nft/ZoraCreator1155Impl.sol:ZoraCreator1155Impl |
+| delegatedTokenId         | mapping(uint32 => uint256)                                               | 562  | 0      | 32    | src/nft/ZoraCreator1155Impl.sol:ZoraCreator1155Impl |
 
 =======================
 ➡ ZoraCreator1155FactoryImpl

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@zoralabs/openzeppelin-contracts-upgradeable": "4.8.4",
     "@zoralabs/protocol-rewards": "1.1.1",
     "ds-test": "https://github.com/dapphub/ds-test#cd98eff28324bfac652e63a239a60632a761790b",
-    "forge-std": "https://github.com/foundry-rs/forge-std#cd7d533f9a0ee0ec02ad81e0a8f262bc4203c653",
+    "forge-std": "https://github.com/foundry-rs/forge-std#705263c95892a906d7af65f0f73ce8a4a0c80b80",
     "solmate": "^6.1.0"
   },
   "devDependencies": {

--- a/src/deployment/DeploymentConfig.sol
+++ b/src/deployment/DeploymentConfig.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.17;
 
 import "forge-std/Test.sol";
+import {CommonBase} from "forge-std/Base.sol";
 import {MintFeeManager} from "../../src/fee/MintFeeManager.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
@@ -76,17 +77,27 @@ abstract contract DeploymentConfig is CommonBase {
         chainConfig.protocolRewards = json.readAddress(getKeyPrefix(PROTOCOL_REWARDS));
     }
 
+    function readAddressOrDefaultToZero(string memory json, string memory key) internal view returns (address addr) {
+        string memory keyPrefix = getKeyPrefix(key);
+
+        if (vm.keyExists(json, keyPrefix)) {
+            addr = json.readAddress(keyPrefix);
+        } else {
+            addr = address(0);
+        }
+    }
+
     /// @notice Get the deployment configuration struct from the JSON configuration file
     /// @return deployment deployment configuration structure
     function getDeployment() internal view returns (Deployment memory deployment) {
         string memory json = vm.readFile(string.concat("addresses/", Strings.toString(chainId()), ".json"));
-        deployment.fixedPriceSaleStrategy = json.readAddress(getKeyPrefix(FIXED_PRICE_SALE_STRATEGY));
-        deployment.merkleMintSaleStrategy = json.readAddress(getKeyPrefix(MERKLE_MINT_SALE_STRATEGY));
-        deployment.redeemMinterFactory = json.readAddress(getKeyPrefix(REDEEM_MINTER_FACTORY));
-        deployment.contract1155Impl = json.readAddress(getKeyPrefix(CONTRACT_1155_IMPL));
-        deployment.factoryImpl = json.readAddress(getKeyPrefix(FACTORY_IMPL));
-        deployment.factoryProxy = json.readAddress(getKeyPrefix(FACTORY_PROXY));
-        deployment.preminter = json.readAddress(getKeyPrefix(PREMINTER));
+        deployment.fixedPriceSaleStrategy = readAddressOrDefaultToZero(json, FIXED_PRICE_SALE_STRATEGY);
+        deployment.merkleMintSaleStrategy = readAddressOrDefaultToZero(json, MERKLE_MINT_SALE_STRATEGY);
+        deployment.redeemMinterFactory = readAddressOrDefaultToZero(json, REDEEM_MINTER_FACTORY);
+        deployment.contract1155Impl = readAddressOrDefaultToZero(json, CONTRACT_1155_IMPL);
+        deployment.factoryImpl = readAddressOrDefaultToZero(json, FACTORY_IMPL);
+        deployment.factoryProxy = readAddressOrDefaultToZero(json, FACTORY_PROXY);
+        deployment.preminter = readAddressOrDefaultToZero(json, PREMINTER);
     }
 }
 

--- a/test/premint/ZoraCreator1155Preminter.t.sol
+++ b/test/premint/ZoraCreator1155Preminter.t.sol
@@ -168,10 +168,6 @@ contract ZoraCreator1155PreminterTest is ForkDeploymentConfig, Test {
     }
 
     function testTheForkPremint(string memory chainName) private {
-        if (keccak256(abi.encodePacked(chainName)) != keccak256(abi.encodePacked("zora_goerli"))) {
-            return;
-        }
-
         console.log("testing on fork: ", chainName);
 
         // create and select the fork, which will be used for all subsequent calls
@@ -180,7 +176,15 @@ contract ZoraCreator1155PreminterTest is ForkDeploymentConfig, Test {
 
         // get contract hash, which is unique per contract creation config, and can be used
         // retreive the address created for a contract
-        preminter = ZoraCreator1155PremintExecutor(getDeployment().preminter);
+        address preminterAddress = getDeployment().preminter;
+
+        if (preminterAddress == address(0)) {
+            console.log("preminter not configured for chain...skipping");
+            return;
+        }
+
+        preminter = ZoraCreator1155PremintExecutor(preminterAddress);
+
         factoryImpl = ZoraCreator1155FactoryImpl(getDeployment().factoryImpl);
 
         console.log("building defaults");
@@ -197,8 +201,6 @@ contract ZoraCreator1155PreminterTest is ForkDeploymentConfig, Test {
         console.log("loading preminter");
 
         address contractAddress = preminter.getContractAddress(contractConfig);
-
-        console.log(contractAddress);
 
         // 2. Call smart contract to get digest to sign for creation params.
         bytes32 digest = ZoraCreator1155Attribution.premintHashedTypeDataV4(premintConfig, contractAddress, chainId);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1823,9 +1823,9 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
 
-"forge-std@https://github.com/foundry-rs/forge-std#cd7d533f9a0ee0ec02ad81e0a8f262bc4203c653":
-  version "1.1.1"
-  resolved "https://github.com/foundry-rs/forge-std#cd7d533f9a0ee0ec02ad81e0a8f262bc4203c653"
+"forge-std@https://github.com/foundry-rs/forge-std#705263c95892a906d7af65f0f73ce8a4a0c80b80":
+  version "1.6.0"
+  resolved "https://github.com/foundry-rs/forge-std#705263c95892a906d7af65f0f73ce8a4a0c80b80"
 
 formdata-polyfill@^4.0.10:
   version "4.0.10"


### PR DESCRIPTION
Fix premint fork tests, they were breaking before if `PREMINTER` was missing from a chain's addresses config

* Update to latest foundry version, and leverage the new `vm.keyExists` method before reading an address
* In premint fork tests, check if address is non 0 for preminter before running the fork test