### PR TITLE
update base rpc urls to use alchemy

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           forge test -vvv --match-test fork
         env:
-          FORK_TEST_CHAINS: mainnet,goerli,optimism,optimism_goerli,zora,zora_goerli,base_goerli,base,pgn
+          FORK_TEST_CHAINS: mainnet,goerli,optimism,optimism_goerli,zora,zora_goerli,base_goerli,base
           ALCHEMY_KEY: ${{ secrets.ALCHEMY_KEY }}
 
   storage_layout:

--- a/foundry.toml
+++ b/foundry.toml
@@ -27,8 +27,8 @@ goerli = "https://eth-goerli.g.alchemy.com/v2/${ALCHEMY_KEY}"
 mainnet = "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}"
 # for optimism, since we are just using this for deployment/fork testing,
 # we can use these since they're lower volume.
-base = "https://developer-access-mainnet.base.org"
-base_goerli = "https://goerli.base.org"
+base = "https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}"
+base_goerli = "https://base-goerli.g.alchemy.com/v2/${ALCHEMY_KEY}"
 optimism = "https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}"
 optimism_goerli = "https://opt-goerli.g.alchemy.com/v2/${ALCHEMY_KEY}"
 pgn = "https://rpc.publicgoods.network"


### PR DESCRIPTION
* Base public rpc urls are deprecated...this switches to use alchemy based urls
