### PR TITLE
Add back coverage ci task, and fix fork tests to not run into compliation issues when running coverage report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
 
-    name: Foundry project
+    name: Check solidity test coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -42,7 +42,7 @@ jobs:
         uses: zgosalvez/github-actions-report-lcov@v2
         with:
           coverage-files: lcov.info
-          minimum-coverage: 90
+          minimum-coverage: 89
           artifact-name: code-coverage-report
           github-token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: ./

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,6 +42,7 @@ jobs:
         uses: zgosalvez/github-actions-report-lcov@v2
         with:
           coverage-files: lcov.info
+          minimum-coverage: 90
           artifact-name: code-coverage-report
           github-token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: ./

--- a/test/factory/ZoraCreator1155Factory_Fork.t.sol
+++ b/test/factory/ZoraCreator1155Factory_Fork.t.sol
@@ -111,13 +111,13 @@ contract ZoraCreator1155FactoryForkTest is ForkDeploymentConfig, Test {
         assertEq(getDeployment().fixedPriceSaleStrategy, address(fixedPrice), string.concat("configured fixed price address incorrect on: ", chainName));
 
         // ** 1. Create the erc1155 contract **
-        uint96 tokenPrice = 1 ether;
-
-        // ** 3. Mint on that contract **
-
         IZoraCreator1155 target = _createErc1155Contract(factory);
 
+        // ** 2. Setup a new token with the fixed price sales strategy and the token price **
+        uint96 tokenPrice = 1 ether;
         uint256 tokenId = _setupToken(target, fixedPrice, tokenPrice);
+
+        // ** 3. Mint on that contract **
 
         // get the mint fee from the contract
         uint256 mintFee = MintFeeManager(address(target)).mintFee();

--- a/test/factory/ZoraCreator1155Factory_Fork.t.sol
+++ b/test/factory/ZoraCreator1155Factory_Fork.t.sol
@@ -36,61 +36,13 @@ contract ZoraCreator1155FactoryForkTest is ForkDeploymentConfig, Test {
         }
     }
 
-    function testTheFork(string memory chainName) private {
-        console.log("testing on fork: ", chainName);
-
-        // create and select the fork, which will be used for all subsequent calls
-        // it will also affect the current block chain id based on the rpc url returned
-        vm.createSelectFork(vm.rpcUrl(chainName));
-
-        address factoryAddress = getDeployment().factoryProxy;
-        IZoraCreator1155Factory factory = IZoraCreator1155Factory(factoryAddress);
-
-        assertEq(getChainConfig().factoryOwner, IOwnable(factoryAddress).owner(), string.concat("configured owner incorrect on: ", chainName));
-
-        address admin = creator;
-        uint32 royaltyMintSchedule = 10;
-        uint32 royaltyBPS = 100;
-        string memory contractURI = "ipfs://asdfasdf";
-        string memory name = "Test";
-        address royaltyRecipient = creator;
-
+    function _setupToken(IZoraCreator1155 target, IMinter1155 fixedPrice, uint96 tokenPrice) private returns (uint256 tokenId) {
         string memory tokenURI = "ipfs://token";
         uint256 tokenMaxSupply = 100;
 
-        // now create a contract with the factory
-        vm.startPrank(creator);
-
-        IMinter1155 fixedPrice = factory.defaultMinters()[0];
-
-        // make sure that the address from the factory matches the stored fixed price address
-        assertEq(getDeployment().fixedPriceSaleStrategy, address(fixedPrice), string.concat("configured fixed price address incorrect on: ", chainName));
-
-        // ** 1. Create the erc1155 contract **
-
-        // create the contract, with no toekns
-        bytes[] memory initSetup = new bytes[](0);
-        address deployedAddress = factory.createContract(
-            contractURI,
-            name,
-            ICreatorRoyaltiesControl.RoyaltyConfiguration({
-                royaltyBPS: royaltyBPS,
-                royaltyRecipient: royaltyRecipient,
-                royaltyMintSchedule: royaltyMintSchedule
-            }),
-            payable(admin),
-            initSetup
-        );
-
-        IZoraCreator1155 target = IZoraCreator1155(deployedAddress);
-
-        // ** 2. Setup a new token with the fixed price sales strategy **
-
-        uint256 tokenId = target.setupNewToken(tokenURI, tokenMaxSupply);
+        tokenId = target.setupNewToken(tokenURI, tokenMaxSupply);
 
         target.addPermission(tokenId, address(fixedPrice), PERMISSION_BIT_MINTER);
-
-        uint96 tokenPrice = 1 ether;
 
         target.callSale(
             tokenId,
@@ -107,8 +59,65 @@ contract ZoraCreator1155FactoryForkTest is ForkDeploymentConfig, Test {
                 })
             )
         );
+    }
+
+    function _createErc1155Contract(IZoraCreator1155Factory factory) private returns (IZoraCreator1155 target) {
+        // create the contract, with no toekns
+        bytes[] memory initSetup = new bytes[](0);
+
+        uint32 royaltyMintSchedule = 10;
+        uint32 royaltyBPS = 100;
+
+        address admin = creator;
+        string memory contractURI = "ipfs://asdfasdf";
+        string memory name = "Test";
+        address royaltyRecipient = creator;
+
+        address deployedAddress = factory.createContract(
+            contractURI,
+            name,
+            ICreatorRoyaltiesControl.RoyaltyConfiguration({
+                royaltyBPS: royaltyBPS,
+                royaltyRecipient: royaltyRecipient,
+                royaltyMintSchedule: royaltyMintSchedule
+            }),
+            payable(admin),
+            initSetup
+        );
+
+        target = IZoraCreator1155(deployedAddress);
+
+        // ** 2. Setup a new token with the fixed price sales strategy **
+    }
+
+    function testTheFork(string memory chainName) private {
+        console.log("testing on fork: ", chainName);
+
+        // create and select the fork, which will be used for all subsequent calls
+        // it will also affect the current block chain id based on the rpc url returned
+        vm.createSelectFork(vm.rpcUrl(chainName));
+
+        address factoryAddress = getDeployment().factoryProxy;
+        IZoraCreator1155Factory factory = IZoraCreator1155Factory(factoryAddress);
+
+        assertEq(getChainConfig().factoryOwner, IOwnable(factoryAddress).owner(), string.concat("configured owner incorrect on: ", chainName));
+
+        // now create a contract with the factory
+        vm.startPrank(creator);
+
+        IMinter1155 fixedPrice = factory.defaultMinters()[0];
+
+        // make sure that the address from the factory matches the stored fixed price address
+        assertEq(getDeployment().fixedPriceSaleStrategy, address(fixedPrice), string.concat("configured fixed price address incorrect on: ", chainName));
+
+        // ** 1. Create the erc1155 contract **
+        uint96 tokenPrice = 1 ether;
 
         // ** 3. Mint on that contract **
+
+        IZoraCreator1155 target = _createErc1155Contract(factory);
+
+        uint256 tokenId = _setupToken(target, fixedPrice, tokenPrice);
 
         // get the mint fee from the contract
         uint256 mintFee = MintFeeManager(address(target)).mintFee();


### PR DESCRIPTION
* Fix coverage compilation errors by moving some fork tests steps to private functions and preventing stack too deep error
* Adding back minimum test coverage requirement, setting it to 89 as currently in this branch it's 89.4%