### PR TITLE
Premint - include erc1155 errors in premint executor abi, by extracting its errors into interface and importing it

### DIFF
--- a/src/interfaces/IZoraCreator1155.sol
+++ b/src/interfaces/IZoraCreator1155.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 import {IERC165Upgradeable} from "@zoralabs/openzeppelin-contracts-upgradeable/contracts/interfaces/IERC165Upgradeable.sol";
 import {IERC1155MetadataURIUpgradeable} from "@zoralabs/openzeppelin-contracts-upgradeable/contracts/interfaces/IERC1155MetadataURIUpgradeable.sol";
 import {IZoraCreator1155TypesV1} from "../nft/IZoraCreator1155TypesV1.sol";
+import {IZoraCreator1155Errors} from "./IZoraCreator1155Errors.sol";
 import {IRenderer1155} from "../interfaces/IRenderer1155.sol";
 import {IMinter1155} from "../interfaces/IMinter1155.sol";
 import {IOwnable} from "../interfaces/IOwnable.sol";
@@ -35,7 +36,7 @@ import {PremintConfig} from "../premint/ZoraCreator1155Attribution.sol";
 
 /// @notice Main interface for the ZoraCreator1155 contract
 /// @author @iainnash / @tbtstl
-interface IZoraCreator1155 is IZoraCreator1155TypesV1, IVersionedContract, IOwnable, IERC1155MetadataURIUpgradeable {
+interface IZoraCreator1155 is IZoraCreator1155TypesV1, IZoraCreator1155Errors, IVersionedContract, IOwnable, IERC1155MetadataURIUpgradeable {
     function PERMISSION_BIT_ADMIN() external returns (uint256);
 
     function PERMISSION_BIT_MINTER() external returns (uint256);
@@ -61,31 +62,6 @@ interface IZoraCreator1155 is IZoraCreator1155TypesV1, IVersionedContract, IOwna
     event ContractMetadataUpdated(address indexed updater, string uri, string name);
     event Purchased(address indexed sender, address indexed minter, uint256 indexed tokenId, uint256 quantity, uint256 value);
     event CreatorAttribution(bytes32 structHash, string domainName, string version, address creator, bytes signature);
-
-    error TokenIdMismatch(uint256 expected, uint256 actual);
-    error UserMissingRoleForToken(address user, uint256 tokenId, uint256 role);
-
-    error Config_TransferHookNotSupported(address proposedAddress);
-
-    error Mint_InsolventSaleTransfer();
-    error Mint_ValueTransferFail();
-    error Mint_TokenIDMintNotAllowed();
-    error Mint_UnknownCommand();
-
-    error Burn_NotOwnerOrApproved(address operator, address user);
-
-    error NewOwnerNeedsToBeAdmin();
-
-    error Sale_CannotCallNonSalesContract(address targetContract);
-
-    error CallFailed(bytes reason);
-    error Renderer_NotValidRendererContract();
-
-    error ETHWithdrawFailed(address recipient, uint256 amount);
-    error FundsWithdrawInsolvent(uint256 amount, uint256 contractValue);
-    error ProtocolRewardsWithdrawFailed(address caller, address recipient, uint256 amount);
-
-    error CannotMintMoreTokens(uint256 tokenId, uint256 quantity, uint256 totalMinted, uint256 maxSupply);
 
     /// @notice Only allow minting one token id at time
     /// @dev Mint contract function that calls the underlying sales function for commands

--- a/src/interfaces/IZoraCreator1155Errors.sol
+++ b/src/interfaces/IZoraCreator1155Errors.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface IZoraCreator1155Errors {
+    error TokenIdMismatch(uint256 expected, uint256 actual);
+    error UserMissingRoleForToken(address user, uint256 tokenId, uint256 role);
+
+    error Config_TransferHookNotSupported(address proposedAddress);
+
+    error Mint_InsolventSaleTransfer();
+    error Mint_ValueTransferFail();
+    error Mint_TokenIDMintNotAllowed();
+    error Mint_UnknownCommand();
+
+    error Burn_NotOwnerOrApproved(address operator, address user);
+
+    error NewOwnerNeedsToBeAdmin();
+
+    error Sale_CannotCallNonSalesContract(address targetContract);
+
+    error CallFailed(bytes reason);
+    error Renderer_NotValidRendererContract();
+
+    error ETHWithdrawFailed(address recipient, uint256 amount);
+    error FundsWithdrawInsolvent(uint256 amount, uint256 contractValue);
+    error ProtocolRewardsWithdrawFailed(address caller, address recipient, uint256 amount);
+
+    error CannotMintMoreTokens(uint256 tokenId, uint256 quantity, uint256 totalMinted, uint256 maxSupply);
+}

--- a/src/premint/ZoraCreator1155PremintExecutor.sol
+++ b/src/premint/ZoraCreator1155PremintExecutor.sol
@@ -6,6 +6,7 @@ import {UUPSUpgradeable} from "@zoralabs/openzeppelin-contracts-upgradeable/cont
 import {Ownable2StepUpgradeable} from "../utils/ownable/Ownable2StepUpgradeable.sol";
 import {IHasContractName} from "../interfaces/IContractMetadata.sol";
 import {IZoraCreator1155} from "../interfaces/IZoraCreator1155.sol";
+import {IZoraCreator1155Errors} from "../interfaces/IZoraCreator1155Errors.sol";
 import {IZoraCreator1155Factory} from "../interfaces/IZoraCreator1155Factory.sol";
 import {SharedBaseConstants} from "../shared/SharedBaseConstants.sol";
 import {ZoraCreatorFixedPriceSaleStrategy} from "../minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.sol";
@@ -16,7 +17,7 @@ import {PremintConfig, ContractCreationConfig, TokenCreationConfig, ZoraCreator1
 /// Signature must provided by the contract creator, or an account that's permitted to create new tokens on the contract.
 /// Mints the first x tokens to the executor of the transaction.
 /// @author @oveddan
-contract ZoraCreator1155PremintExecutor is Ownable2StepUpgradeable, UUPSUpgradeable, IHasContractName {
+contract ZoraCreator1155PremintExecutor is Ownable2StepUpgradeable, UUPSUpgradeable, IHasContractName, IZoraCreator1155Errors {
     IZoraCreator1155Factory public immutable zora1155Factory;
 
     /// @notice copied from SharedBaseConstants

--- a/test/factory/ZoraCreator1155Factory.t.sol
+++ b/test/factory/ZoraCreator1155Factory.t.sol
@@ -8,6 +8,7 @@ import {ZoraCreator1155Impl} from "../../src/nft/ZoraCreator1155Impl.sol";
 import {Zora1155Factory} from "../../src/proxies/Zora1155Factory.sol";
 import {IZoraCreator1155Factory} from "../../src/interfaces/IZoraCreator1155Factory.sol";
 import {IZoraCreator1155} from "../../src/interfaces/IZoraCreator1155.sol";
+import {IZoraCreator1155Errors} from "../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IMinter1155} from "../../src/interfaces/IMinter1155.sol";
 import {ICreatorRoyaltiesControl} from "../../src/interfaces/ICreatorRoyaltiesControl.sol";
 import {Zora1155} from "../../src/proxies/Zora1155.sol";

--- a/test/factory/ZoraCreator1155Factory_Fork.t.sol
+++ b/test/factory/ZoraCreator1155Factory_Fork.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.17;
 
 import "forge-std/Test.sol";
 import {IZoraCreator1155Factory} from "../../src/interfaces/IZoraCreator1155Factory.sol";
+import {IZoraCreator1155Errors} from "../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IZoraCreator1155} from "../../src/interfaces/IZoraCreator1155.sol";
 import {ZoraCreator1155Impl} from "../../src/nft/ZoraCreator1155Impl.sol";
 import {IMinter1155} from "../../src/interfaces/IMinter1155.sol";

--- a/test/fixtures/Zora1155FactoryFixtures.sol
+++ b/test/fixtures/Zora1155FactoryFixtures.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.17;
 
 import {ZoraCreator1155Impl} from "../../src/nft/ZoraCreator1155Impl.sol";
 import {ZoraCreatorFixedPriceSaleStrategy} from "../../src/minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.sol";
+import {IZoraCreator1155Errors} from "../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IZoraCreator1155} from "../../src/interfaces/IZoraCreator1155.sol";
 import {IMinter1155} from "../../src/interfaces/IMinter1155.sol";
 import {Zora1155Factory} from "../../src/proxies/Zora1155Factory.sol";

--- a/test/fixtures/Zora1155PremintFixtures.sol
+++ b/test/fixtures/Zora1155PremintFixtures.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import {ZoraCreator1155Impl} from "../../src/nft/ZoraCreator1155Impl.sol";
 import {ZoraCreatorFixedPriceSaleStrategy} from "../../src/minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.sol";
-import {IZoraCreator1155} from "../../src/interfaces/IZoraCreator1155.sol";
+import {IZoraCreator1155Errors} from "../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IMinter1155} from "../../src/interfaces/IMinter1155.sol";
 import {ICreatorRoyaltiesControl} from "../../src/interfaces/ICreatorRoyaltiesControl.sol";
 import {Zora1155Factory} from "../../src/proxies/Zora1155Factory.sol";

--- a/test/minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.t.sol
+++ b/test/minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 import {ProtocolRewards} from "@zoralabs/protocol-rewards/src/ProtocolRewards.sol";
 import {ZoraCreator1155Impl} from "../../../src/nft/ZoraCreator1155Impl.sol";
 import {Zora1155} from "../../../src/proxies/Zora1155.sol";
-import {IZoraCreator1155} from "../../../src/interfaces/IZoraCreator1155.sol";
+import {IZoraCreator1155Errors} from "../../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IMinter1155} from "../../../src/interfaces/IMinter1155.sol";
 import {ICreatorRoyaltiesControl} from "../../../src/interfaces/ICreatorRoyaltiesControl.sol";
 import {IZoraCreator1155Factory} from "../../../src/interfaces/IZoraCreator1155Factory.sol";

--- a/test/minters/merkle/ZoraCreatorMerkleMinterStrategy.t.sol
+++ b/test/minters/merkle/ZoraCreatorMerkleMinterStrategy.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 import {ProtocolRewards} from "@zoralabs/protocol-rewards/src/ProtocolRewards.sol";
 import {ZoraCreator1155Impl} from "../../../src/nft/ZoraCreator1155Impl.sol";
 import {Zora1155} from "../../../src/proxies/Zora1155.sol";
-import {IZoraCreator1155} from "../../../src/interfaces/IZoraCreator1155.sol";
+import {IZoraCreator1155Errors} from "../../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IRenderer1155} from "../../../src/interfaces/IRenderer1155.sol";
 import {ICreatorRoyaltiesControl} from "../../../src/interfaces/ICreatorRoyaltiesControl.sol";
 import {ILimitedMintPerAddress} from "../../../src/interfaces/ILimitedMintPerAddress.sol";

--- a/test/minters/redeem/ZoraCreatorRedeemMinterFactory.t.sol
+++ b/test/minters/redeem/ZoraCreatorRedeemMinterFactory.t.sol
@@ -9,7 +9,7 @@ import {ProtocolRewards} from "@zoralabs/protocol-rewards/src/ProtocolRewards.so
 import {ZoraCreator1155Impl} from "../../../src/nft/ZoraCreator1155Impl.sol";
 import {Zora1155} from "../../../src/proxies/Zora1155.sol";
 import {IMinter1155} from "../../../src/interfaces/IMinter1155.sol";
-import {IZoraCreator1155} from "../../../src/interfaces/IZoraCreator1155.sol";
+import {IZoraCreator1155Errors} from "../../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IRenderer1155} from "../../../src/interfaces/IRenderer1155.sol";
 import {ICreatorRoyaltiesControl} from "../../../src/interfaces/ICreatorRoyaltiesControl.sol";
 import {IZoraCreator1155Factory} from "../../../src/interfaces/IZoraCreator1155Factory.sol";

--- a/test/minters/redeem/ZoraCreatorRedeemMinterStrategy.t.sol
+++ b/test/minters/redeem/ZoraCreatorRedeemMinterStrategy.t.sol
@@ -8,7 +8,7 @@ import {ERC1155PresetMinterPauser} from "@openzeppelin/contracts/token/ERC1155/p
 import {ProtocolRewards} from "@zoralabs/protocol-rewards/src/ProtocolRewards.sol";
 import {ZoraCreator1155Impl} from "../../../src/nft/ZoraCreator1155Impl.sol";
 import {Zora1155} from "../../../src/proxies/Zora1155.sol";
-import {IZoraCreator1155} from "../../../src/interfaces/IZoraCreator1155.sol";
+import {IZoraCreator1155Errors} from "../../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IRenderer1155} from "../../../src/interfaces/IRenderer1155.sol";
 import {ICreatorRoyaltiesControl} from "../../../src/interfaces/ICreatorRoyaltiesControl.sol";
 import {IZoraCreator1155Factory} from "../../../src/interfaces/IZoraCreator1155Factory.sol";

--- a/test/nft/ZoraCreator1155.t.sol
+++ b/test/nft/ZoraCreator1155.t.sol
@@ -10,6 +10,7 @@ import {ZoraCreator1155Impl} from "../../src/nft/ZoraCreator1155Impl.sol";
 import {Zora1155} from "../../src/proxies/Zora1155.sol";
 import {ZoraCreatorFixedPriceSaleStrategy} from "../../src/minters/fixed-price/ZoraCreatorFixedPriceSaleStrategy.sol";
 
+import {IZoraCreator1155Errors} from "../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IZoraCreator1155} from "../../src/interfaces/IZoraCreator1155.sol";
 import {IRenderer1155} from "../../src/interfaces/IRenderer1155.sol";
 import {IZoraCreator1155TypesV1} from "../../src/nft/IZoraCreator1155TypesV1.sol";
@@ -215,7 +216,7 @@ contract ZoraCreator1155Test is Test {
     function test_setupNewToken_revertOnlyAdminOrRole() external {
         init();
 
-        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.UserMissingRoleForToken.selector, address(this), 0, target.PERMISSION_BIT_MINTER()));
+        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155Errors.UserMissingRoleForToken.selector, address(this), 0, target.PERMISSION_BIT_MINTER()));
         target.setupNewToken("test", 1);
     }
 
@@ -260,7 +261,7 @@ contract ZoraCreator1155Test is Test {
     function test_setTokenMetadataRenderer_revertOnlyAdminOrRole() external {
         init();
 
-        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.UserMissingRoleForToken.selector, address(this), 0, target.PERMISSION_BIT_METADATA()));
+        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155Errors.UserMissingRoleForToken.selector, address(this), 0, target.PERMISSION_BIT_METADATA()));
         target.setTokenMetadataRenderer(0, IRenderer1155(address(0)));
     }
 
@@ -281,7 +282,7 @@ contract ZoraCreator1155Test is Test {
         vm.assume(tokenId != 0);
         init();
 
-        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.UserMissingRoleForToken.selector, recipient, tokenId, adminRole));
+        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155Errors.UserMissingRoleForToken.selector, recipient, tokenId, adminRole));
         vm.prank(recipient);
         target.addPermission(tokenId, recipient, adminRole);
     }
@@ -332,7 +333,7 @@ contract ZoraCreator1155Test is Test {
         vm.assume(tokenId != 0);
         init();
 
-        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.UserMissingRoleForToken.selector, recipient, tokenId, adminRole));
+        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155Errors.UserMissingRoleForToken.selector, recipient, tokenId, adminRole));
         vm.prank(recipient);
         target.removePermission(tokenId, address(0), adminRole);
     }
@@ -413,7 +414,9 @@ contract ZoraCreator1155Test is Test {
         vm.prank(admin);
         uint256 tokenId = target.setupNewToken("test", 1000);
 
-        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.UserMissingRoleForToken.selector, address(this), tokenId, target.PERMISSION_BIT_MINTER()));
+        vm.expectRevert(
+            abi.encodeWithSelector(IZoraCreator1155Errors.UserMissingRoleForToken.selector, address(this), tokenId, target.PERMISSION_BIT_MINTER())
+        );
         target.adminMint(address(0), tokenId, 0, "");
     }
 
@@ -424,7 +427,7 @@ contract ZoraCreator1155Test is Test {
         vm.prank(admin);
         uint256 tokenId = target.setupNewToken("test", quantity - 1);
 
-        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.CannotMintMoreTokens.selector, tokenId, quantity, 0, quantity - 1));
+        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155Errors.CannotMintMoreTokens.selector, tokenId, quantity, 0, quantity - 1));
         vm.prank(admin);
         target.adminMint(recipient, tokenId, quantity, "");
     }
@@ -540,7 +543,9 @@ contract ZoraCreator1155Test is Test {
         tokenIds[0] = tokenId;
         quantities[0] = 0;
 
-        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.UserMissingRoleForToken.selector, address(this), tokenId, target.PERMISSION_BIT_MINTER()));
+        vm.expectRevert(
+            abi.encodeWithSelector(IZoraCreator1155Errors.UserMissingRoleForToken.selector, address(this), tokenId, target.PERMISSION_BIT_MINTER())
+        );
         target.adminMintBatch(address(0), tokenIds, quantities, "");
     }
 
@@ -556,7 +561,7 @@ contract ZoraCreator1155Test is Test {
         tokenIds[0] = tokenId;
         quantities[0] = quantity;
 
-        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.CannotMintMoreTokens.selector, tokenId, quantity, 0, quantity - 1));
+        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155Errors.CannotMintMoreTokens.selector, tokenId, quantity, 0, quantity - 1));
         vm.prank(admin);
         target.adminMintBatch(recipient, tokenIds, quantities, "");
     }
@@ -605,7 +610,7 @@ contract ZoraCreator1155Test is Test {
         vm.prank(admin);
         uint256 tokenId = target.setupNewToken("test", 1000);
 
-        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.UserMissingRoleForToken.selector, address(0), tokenId, target.PERMISSION_BIT_MINTER()));
+        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155Errors.UserMissingRoleForToken.selector, address(0), tokenId, target.PERMISSION_BIT_MINTER()));
         target.mint(SimpleMinter(payable(address(0))), tokenId, 0, "");
     }
 
@@ -621,7 +626,7 @@ contract ZoraCreator1155Test is Test {
 
         target.addPermission(tokenId, address(simpleMinter), adminRole);
 
-        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.CannotMintMoreTokens.selector, tokenId, 1001, 0, 1000));
+        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155Errors.CannotMintMoreTokens.selector, tokenId, 1001, 0, 1000));
         target.mint{value: totalReward}(simpleMinter, tokenId, 1001, abi.encode(recipient));
 
         vm.stopPrank();
@@ -1071,7 +1076,7 @@ contract ZoraCreator1155Test is Test {
         target.callSale(tokenId, simpleMinter, abi.encodeWithSignature("setNum(uint256)", 1));
         assertEq(simpleMinter.num(), 1);
 
-        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.CallFailed.selector, ""));
+        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155Errors.CallFailed.selector, ""));
         target.callSale(tokenId, simpleMinter, abi.encodeWithSignature("setNum(uint256)", 0));
 
         vm.stopPrank();
@@ -1093,7 +1098,7 @@ contract ZoraCreator1155Test is Test {
         target.callRenderer(tokenId, abi.encodeWithSelector(SimpleRenderer.setup.selector, "callRender successful"));
         assertEq(target.uri(tokenId), "callRender successful");
 
-        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.CallFailed.selector, ""));
+        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155Errors.CallFailed.selector, ""));
         target.callRenderer(tokenId, abi.encodeWithSelector(SimpleRenderer.setup.selector, ""));
 
         vm.stopPrank();
@@ -1148,7 +1153,7 @@ contract ZoraCreator1155Test is Test {
         uint256 tokenId = target.setupNewToken("", 1);
         target.setTokenMetadataRenderer(tokenId, renderer);
 
-        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.CallFailed.selector, ""));
+        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155Errors.CallFailed.selector, ""));
         target.callRenderer(tokenId, "0xfoobar");
     }
 
@@ -1268,7 +1273,7 @@ contract ZoraCreator1155Test is Test {
         vm.prank(admin);
         target.mint{value: totalValue}(simpleMinter, tokenId, 1000, abi.encode(recipient));
 
-        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.ETHWithdrawFailed.selector, simpleMinter, 1 ether));
+        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155Errors.ETHWithdrawFailed.selector, simpleMinter, 1 ether));
         vm.prank(address(simpleMinter));
         target.withdraw();
     }

--- a/test/nft/ZoraCreator1155AccessControlGeneralTest.sol
+++ b/test/nft/ZoraCreator1155AccessControlGeneralTest.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 import {ProtocolRewards} from "@zoralabs/protocol-rewards/src/ProtocolRewards.sol";
 import {ZoraCreator1155Impl} from "../../src/nft/ZoraCreator1155Impl.sol";
 import {Zora1155} from "../../src/proxies/Zora1155.sol";
-import {IZoraCreator1155} from "../../src/interfaces/IZoraCreator1155.sol";
+import {IZoraCreator1155Errors} from "../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IRenderer1155} from "../../src/interfaces/IRenderer1155.sol";
 import {IMinter1155} from "../../src/interfaces/IMinter1155.sol";
 import {IZoraCreator1155TypesV1} from "../../src/nft/IZoraCreator1155TypesV1.sol";

--- a/test/premint/ZoraCreator1155PremintExecutor.t.sol
+++ b/test/premint/ZoraCreator1155PremintExecutor.t.sol
@@ -7,6 +7,7 @@ import {ProtocolRewards} from "@zoralabs/protocol-rewards/src/ProtocolRewards.so
 
 import {ZoraCreator1155Impl} from "../../src/nft/ZoraCreator1155Impl.sol";
 import {Zora1155} from "../../src/proxies/Zora1155.sol";
+import {IZoraCreator1155Errors} from "../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IZoraCreator1155} from "../../src/interfaces/IZoraCreator1155.sol";
 import {IMinter1155} from "../../src/interfaces/IMinter1155.sol";
 import {ICreatorRoyaltiesControl} from "../../src/interfaces/ICreatorRoyaltiesControl.sol";
@@ -415,7 +416,7 @@ contract ZoraCreator1155PreminterTest is ForkDeploymentConfig, Test {
         // the expected UserMissingRole error
         vm.expectRevert(
             abi.encodeWithSelector(
-                IZoraCreator1155.UserMissingRoleForToken.selector,
+                IZoraCreator1155Errors.UserMissingRoleForToken.selector,
                 address(preminter),
                 newTokenId,
                 ZoraCreator1155Impl(address(created1155Contract)).PERMISSION_BIT_SALES()
@@ -439,7 +440,7 @@ contract ZoraCreator1155PreminterTest is ForkDeploymentConfig, Test {
         // have the premint contract try to set royalties config - it should revert
         vm.expectRevert(
             abi.encodeWithSelector(
-                IZoraCreator1155.UserMissingRoleForToken.selector,
+                IZoraCreator1155Errors.UserMissingRoleForToken.selector,
                 address(preminter),
                 newTokenId,
                 ZoraCreator1155Impl(address(created1155Contract)).PERMISSION_BIT_FUNDS_MANAGER()
@@ -631,7 +632,7 @@ contract ZoraCreator1155PreminterTest is ForkDeploymentConfig, Test {
         vm.deal(premintExecutor, mintCost);
 
         // try to mint, it should revert
-        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155.UserMissingRoleForToken.selector, newCreator, CONTRACT_BASE_ID, PERMISSION_BIT_MINTER));
+        vm.expectRevert(abi.encodeWithSelector(IZoraCreator1155Errors.UserMissingRoleForToken.selector, newCreator, CONTRACT_BASE_ID, PERMISSION_BIT_MINTER));
         vm.prank(premintExecutor);
         preminter.premint{value: mintCost}(contractConfig, premintConfig2, newCreatorSignature, quantityToMint, "yo");
 

--- a/test/royalties/CreatorRoyaltiesControl.t.sol
+++ b/test/royalties/CreatorRoyaltiesControl.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 import {ProtocolRewards} from "@zoralabs/protocol-rewards/src/ProtocolRewards.sol";
 import {ZoraCreator1155Impl} from "../../src/nft/ZoraCreator1155Impl.sol";
 import {Zora1155} from "../../src/proxies/Zora1155.sol";
-import {IZoraCreator1155} from "../../src/interfaces/IZoraCreator1155.sol";
+import {IZoraCreator1155Errors} from "../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IZoraCreator1155TypesV1} from "../../src/nft/IZoraCreator1155TypesV1.sol";
 import {ICreatorRoyaltiesControl} from "../../src/interfaces/ICreatorRoyaltiesControl.sol";
 import {IZoraCreator1155Factory} from "../../src/interfaces/IZoraCreator1155Factory.sol";

--- a/test/utils/Ownable2StepUpgradable.t.sol
+++ b/test/utils/Ownable2StepUpgradable.t.sol
@@ -6,6 +6,7 @@ import {Ownable2StepUpgradeable} from "../../src/utils/ownable/Ownable2StepUpgra
 import {IOwnable2StepUpgradeable} from "../../src/utils/ownable/IOwnable2StepUpgradeable.sol";
 import {ZoraCreator1155FactoryImpl} from "../../src/factory/ZoraCreator1155FactoryImpl.sol";
 import {Zora1155Factory} from "../../src/proxies/Zora1155Factory.sol";
+import {IZoraCreator1155Errors} from "../../src/interfaces/IZoraCreator1155Errors.sol";
 import {IZoraCreator1155} from "../../src/interfaces/IZoraCreator1155.sol";
 import {IMinter1155} from "../../src/interfaces/IMinter1155.sol";
 import {IZoraCreator1155Factory} from "../../src/interfaces/IZoraCreator1155Factory.sol";


### PR DESCRIPTION
Alternate and cleaner approach to #169 