### PR TITLE
Prerelease workflow for versioning + publishing prerelease tags

### DIFF
--- a/.github/workflows/changesets-prerelease.yml
+++ b/.github/workflows/changesets-prerelease.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - "*prerelease*"
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Check pre.json existence
+        id: check_pre
+        uses: andstor/file-existence-action@v1
+        with:
+          files: ".changeset/pre.json"
+
+      - name: Ensure pre.json exists
+        if: steps.check_pre.outputs.files_exists != 'true'
+        run: echo "pre.json does not exist, enter prerelease mode with 'yarn changeset pre enter {prereleaseName}'"; exit 1
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "yarn"
+
+      - name: Install project dependencies
+        run: yarn
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          # This expects you to have a script called release which does a build for your packages and calls changeset publish
+          publish: yarn release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds a github action for `prerelease` branches, that:
* if the branch name has `*prerelease*`, open up a changeset `Version Packages` pr for the prerelease branch, which bumps the version based on the changesets.
* If that branch is merged back into the `prerelease` branch, a release will be created in github and published to npm, using the prerelease tag

It requires that `.changeset/pre.json` exists, to enforce that this is publishing a pre-release version and not overriding main

The version packages pr looks like:

![Screenshot 2023-09-18 at 12.09.14 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ApIDvpfodCPhycVfvWex/e34063ec-f650-4065-bb24-f7412dc3dd4e/Screenshot%202023-09-18%20at%2012.09.14%20PM.png)

where the tag name is added in parenthesis after the PR name, in this example, the tag name is `gasless`, and PR name is `Version Packages (gasless)`


![Screenshot 2023-09-18 at 12.09.20 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ApIDvpfodCPhycVfvWex/add60cb4-cb91-467f-b5ec-fb6274c56e27/Screenshot%202023-09-18%20at%2012.09.20%20PM.png)

