### PR TITLE
Prerelease workflow for versioning + publishing prerelease tags

### DIFF
--- a/.github/workflows/changesets-prerelease.yml
+++ b/.github/workflows/changesets-prerelease.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - "*prerelease*"
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Check pre.json existence
+        id: check_pre
+        uses: andstor/file-existence-action@v1
+        with:
+          files: ".changeset/pre.json"
+
+      - name: Ensure pre.json exists
+        if: steps.check_pre.outputs.files_exists != 'true'
+        run: echo "pre.json does not exist, enter prerelease mode with 'yarn changeset pre enter {prereleaseName}'"; exit 1
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "yarn"
+
+      - name: Install project dependencies
+        run: yarn
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          # This expects you to have a script called release which does a build for your packages and calls changeset publish
+          publish: yarn release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Duplicate of #179 but as its own PR:

Prerelease workflow docs can [be found here](https://github.com/changesets/changesets/blob/main/docs/prereleases.md)

Adds a github action for `prerelease` branches, that enabled prerelease packages to be versioned, tagged, and published to npm, with changes in the pre-release documented.
How does it work?
* if a branch is pushed and has the name `*prerelease*`, a new [Changeset Github Action](https://github.com/changesets/action) will open up `changeset` `Version Packages` pr for the prerelease branch, which bumps the version based on the changesets.  **That branch must be in `prerelease` mode** for it's changesets, i.e. having the file `.changeset/pre.json`.  This can be added by: `yarn changeset pre enter {prerelease name}`.  This is to prevent code in prerelease branches to accidentally publish versions non-prerelease branches and overriding the versions from `main`
* If that Version Package branch is merged back into the `prerelease` branch, a release will be created in github and published to npm, using the prerelease will be tagged and stored in the github repo, with all changes documented via the changesets and changelog.

Step by step instructions:
* do some dev work.
* add and commit a changeset: `npx changeset`  then add and commit the new files to git
* Push the branch: `gt submit`
* When ready to create a prerelease, check out a new branch that contains `prerelease` in the title: `gt branch create premint-prerelease`
* Enter prerelease mode in `changesets`: `yarn changeset pre enter {prerelease name}`
* Add the new files, commit them, and push to github.
* a Github action should detect the new changeset, and open a PR `Version Packages {prerelease name}`, where the versions are updated.

The version packages pr looks like:

![Screenshot 2023-09-18 at 12.09.14 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ApIDvpfodCPhycVfvWex/e34063ec-f650-4065-bb24-f7412dc3dd4e/Screenshot%202023-09-18%20at%2012.09.14%20PM.png)

where the tag name is added in parenthesis after the PR name, in this example, the tag name is `gasless`, and PR name is `Version Packages (gasless)`

![Screenshot 2023-09-18 at 12.09.20 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ApIDvpfodCPhycVfvWex/add60cb4-cb91-467f-b5ec-fb6274c56e27/Screenshot%202023-09-18%20at%2012.09.20%20PM.png)

* Merge the version packages PR, this will create the tag, publish the release to github, and publish the version to npm.

Here is what the release looks like:
<img width="1236" alt="Screenshot 2023-09-19 at 3 34 22 PM" src="https://github.com/ourzora/zora-1155-contracts/assets/891755/ec27a3d1-ee89-4360-af4f-37a9441f3f5a">
